### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "start"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+[![Run on Repl.it](https://repl.it/badge/github/kallyas/advanced-drop-down-menu)](https://repl.it/github/kallyas/advanced-drop-down-menu)
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 ## Available Scripts


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).